### PR TITLE
[SOL] Prohibit printing in SBF backend

### DIFF
--- a/zig/lib/std/testing.zig
+++ b/zig/lib/std/testing.zig
@@ -22,7 +22,7 @@ pub var base_allocator_instance = std.heap.FixedBufferAllocator.init("");
 pub var log_level = std.log.Level.warn;
 
 // Disable printing in tests for simple backends.
-pub const backend_can_print = builtin.zig_backend != .stage2_spirv64;
+pub const backend_can_print = builtin.zig_backend != .stage2_spirv64 and builtin.os.tag != .solana;
 
 fn print(comptime fmt: []const u8, args: anytype) void {
     if (@inComptime()) {


### PR DESCRIPTION
#### Problem

It isn't possible to use helpers like `std.testing.expectEqual` in SBF because the backend allows printing, and fails compilation.

#### Solution

Specify that the solana backend doesn't allow printing.