### PR TITLE
[SOL] Alias mem syscalls to sol_mem variants

### DIFF
--- a/zig/lib/compiler_rt/memcmp.zig
+++ b/zig/lib/compiler_rt/memcmp.zig
@@ -1,8 +1,19 @@
 const std = @import("std");
 const common = @import("./common.zig");
+const builtin = @import("builtin");
 
 comptime {
-    @export(memcmp, .{ .name = "memcmp", .linkage = common.linkage, .visibility = common.visibility });
+    if (builtin.os.tag == .solana) {
+        const Syscall = struct {
+            extern fn sol_memcmp_(vl: [*]const u8, vr: [*]const u8, n: usize) callconv(.C) c_int;
+            pub fn sol_memcmp(vl: [*]const u8, vr: [*]const u8, n: usize) callconv(.C) c_int {
+                return sol_memcmp_(vl, vr, n);
+            }
+        };
+        @export(Syscall.sol_memcmp, .{ .name = "memcmp", .linkage = common.linkage, .visibility = common.visibility });
+    } else {
+        @export(memcmp, .{ .name = "memcmp", .linkage = common.linkage, .visibility = common.visibility });
+    }
 }
 
 pub fn memcmp(vl: [*]const u8, vr: [*]const u8, n: usize) callconv(.C) c_int {

--- a/zig/lib/compiler_rt/memcpy.zig
+++ b/zig/lib/compiler_rt/memcpy.zig
@@ -4,7 +4,18 @@ const builtin = @import("builtin");
 
 comptime {
     if (builtin.object_format != .c) {
-        @export(memcpy, .{ .name = "memcpy", .linkage = common.linkage, .visibility = common.visibility });
+        if (builtin.os.tag == .solana) {
+            const Syscall = struct {
+                extern fn sol_memcpy_(noalias dest: ?[*]u8, noalias src: ?[*]const u8, len: usize) callconv(.C) void;
+                pub fn sol_memcpy(noalias dest: ?[*]u8, noalias src: ?[*]const u8, len: usize) callconv(.C) ?[*]u8 {
+                    sol_memcpy_(dest, src, len);
+                    return dest;
+                }
+            };
+            @export(Syscall.sol_memcpy, .{ .name = "memcpy", .linkage = common.linkage, .visibility = common.visibility });
+        } else {
+            @export(memcpy, .{ .name = "memcpy", .linkage = common.linkage, .visibility = common.visibility });
+        }
     }
 }
 

--- a/zig/lib/compiler_rt/memset.zig
+++ b/zig/lib/compiler_rt/memset.zig
@@ -4,7 +4,17 @@ const builtin = @import("builtin");
 
 comptime {
     if (builtin.object_format != .c) {
-        @export(memset, .{ .name = "memset", .linkage = common.linkage, .visibility = common.visibility });
+        if (builtin.os.tag == .solana) {
+            const Syscall = struct {
+                extern fn sol_memset_(dest: ?[*]u8, c: u8, len: usize) callconv(.C) ?[*]u8;
+                pub fn sol_memset(dest: ?[*]u8, c: u8, len: usize) callconv(.C) ?[*]u8 {
+                    return sol_memset_(dest, c, len);
+                }
+            };
+            @export(Syscall.sol_memset, .{ .name = "memset", .linkage = common.linkage, .visibility = common.visibility });
+        } else {
+            @export(memset, .{ .name = "memset", .linkage = common.linkage, .visibility = common.visibility });
+        }
         @export(__memset, .{ .name = "__memset", .linkage = common.linkage, .visibility = common.visibility });
     }
 }


### PR DESCRIPTION
#### Problem

The memory syscalls (memset, memcpy, memmove, memcmp) don't exist on Solana. The sol_mem variants exist, but the backend doesn't know to use them.

#### Solution

Call them for the solana backend.

Fixes #1